### PR TITLE
Fix TS 3.7.x duplicate conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,9 +34,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
-      "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q==",
+      "version": "12.12.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
+      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -904,9 +904,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "upper-case": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Cucumber test runner with several condiments",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,12 +16,12 @@
   "homepage": "https://github.com/muralco/pickled-cucumber",
   "devDependencies": {
     "@types/cucumber": "^4.0.7",
-    "@types/node": "^10.5.2",
+    "@types/node": "^12.12.14",
     "@types/node-fetch": "^2.1.2",
     "ts-unused-exports": "^2.0.10",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.9.2",
-    "typescript": "^3.5.2"
+    "typescript": "^3.7.3"
   },
   "dependencies": {
     "cucumber": "^4.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import printSteps from './steps/printer';
 import { Step, StepKind } from './steps/types';
 import {
   Aliases,
-  Options,
+  Options as BaseOptions,
   SetupFnArgs,
   StepDefinitionFn,
   TearDownFn,
@@ -31,7 +31,7 @@ import {
 
 export { getVariables } from './aliases';
 
-export type Options = Options;
+export type Options = BaseOptions;
 
 export type SetupFn = (args: SetupFnArgs) => void;
 

--- a/src/operators/includes.ts
+++ b/src/operators/includes.ts
@@ -6,13 +6,15 @@ interface Offending {
   path: string | undefined;
 }
 
+const isObject = (item: unknown): item is Object =>
+  typeof item === 'object' && !Array.isArray(item) && item !== null;
+
 const recursiveIncludes = (
   actual: unknown,
   expectedPartial: unknown,
   path?: string,
 ) => {
-  const expected = typeof expectedPartial === 'object'
-    && !Array.isArray(expectedPartial)
+  const expected = isObject(actual) && isObject(expectedPartial)
     ? { ...actual, ...expectedPartial } // make a whole object from a partial
     : expectedPartial; // is a primitive or array
 


### PR DESCRIPTION
fixes https://github.com/muralco/pickled-cucumber/issues/5

In TS 3.7 a new checking was [introduced](http://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#function-truthy-checks). This PR fixes this conflict when `pickled-cucumber` is used along with TS.