### PR TITLE
Allow regex string to include /s flag

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -94,10 +94,10 @@ export const getDeep = (o: unknown, path: string): unknown|undefined =>
     );
 
 export const stringToRegexp = (str: string): RegExp => {
-  const [flags] = (str.match(/\/([gimuy]+)$/) || []).slice(1);
+  const [flags] = (str.match(/\/([gimusy]+)$/) || []).slice(1);
 
   const expectedString = str
-    .replace(/^\/(.*)\/[gimuy]*$/, '$1')
+    .replace(/^\/(.*)\/[gimusy]*$/, '$1')
     .replace(/^"(.*)"$/, '$1');
 
   return new RegExp(expectedString, flags);


### PR DESCRIPTION
**What changes does this PR introduce?**

This PR allows regex strings parsed by `stringToRegexp` helper to include `s` flag (allows a dot `.` to match newline character `\n`).

**Motivation and context**

I had to test that a string matched some regex, but I haven't been able to do it since said string included a newline character `\n`, and I needed to use the `/s` flag to match the entire string.