### PR TITLE
Add functionality to capture and suppress stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ steps.
 
 Now here is where things get really interesting: variables can be interpolated
 into any steps in `pickled-cucumber` in a similar fashion as how strings
-are interpolated in JavaScript. 
+are interpolated in JavaScript.
 
 For example:
 
@@ -490,6 +490,72 @@ Because there is a lot more to this module, we have more detailed
 documentation in a separate place, see:
 
 > [Entities Module](docs/entities.md#entities-module).
+
+### Output Module
+
+The _output module_ enables capture and suppression of stdout and stderr when tests are runned.
+
+To enable the _output module_ you have the following options:
+
+```js
+const options = {
+  captureOutput: true  // Will present captured stdout and stderr if an step fails
+  suppressOutput: true  // Will hide stdout and stderr emitted by each step
+};
+
+const fn = (args) => {
+  // define your steps here using args
+}
+
+setup(fn, options);
+```
+
+Reported output will be like the following example (only if a test fails):
+```
+Failures:
+
+1) Scenario: { "a": 1 } at a is 2 # features/operators/at.feature:8
+   ✔ Before # src/index.ts:62
+   ✔ Before # src/output.ts:47
+   ✔ Given A is { "a": 1 } # src/index.ts:144
+   ✔ When asserting that A at a is 2 # src/index.ts:146
+   ✔ Then the assertion fails with 1 is not 2 # src/index.ts:145
+   ✖ And the full actual value is { "a": 7} # src/index.ts:145
+       AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Expected values to be loosely deep-equal:
+
+       {
+         a: 7
+       }
+
+       should loosely deep-equal
+
+       {
+         a: 1
+       }
+           + expected - actual
+
+            {
+           -  "a": 7
+           +  "a": 1
+            }
+
+           at Then.inline (pickled-cucumber/src/test.ts:127:22)
+           at Object.eval (eval at proxyFnFor (pickled-cucumber/src/steps/constructor.ts:48:32), <anonymous>:6:12)
+
+       Captured Output
+       ===============
+       Std Err
+       -------
+       <Nothing was captured>
+
+       Std Out
+       -------
+       If your are seing this tests are broken
+```
+Note: capture functionality is disabled if _debug module_ is enabled.
+
+#### Caveats
+Deprecation warnings, and output emitted from `v8` or `c++` modules will not be captured.
 
 ### Operators Module
 

--- a/features/output.feature
+++ b/features/output.feature
@@ -1,0 +1,183 @@
+Feature: capture and suppress output
+
+Background:
+  Given step definition
+  """
+  const fn: SetupFn = ({ Given, Then }) => {
+    Given('message (.*) is written to stdout', (msg) => console.log(msg));
+    Given('message (.*) is written to stderr', (msg) => console.error(msg));
+    Then('no error', () => {});
+    Then('error', () => {throw new Error('Error')});
+  }
+  """
+  And feature file is
+  """
+  Feature: test the output module
+
+  Scenario: all ok
+    When message Hello world is written to stdout
+    And message Bye Bye is written to stderr
+    Then no error
+
+  Scenario: error
+    When message Hello world is written to stdout
+    And message Bye Bye is written to stderr
+    Then error
+  """
+
+Scenario: Capture and suppression disabled
+  When the suite is executed
+  Then stdout contains
+  """
+  .Hello world
+  .....Hello world
+  ..F.
+
+  Failures:
+
+  1) Scenario: error
+     ✔ Before
+     ✔ When message Hello world is written to stdout
+     ✔ And message Bye Bye is written to stderr
+     ✖ Then error
+         Error: Error
+     ✔ After
+
+  2 scenarios (1 failed, 1 passed)
+  6 steps (1 failed, 5 passed)
+  """
+  And stderr contains
+  """
+  Bye Bye
+  Bye Bye
+  """
+
+Scenario: Capture enabled and suppression disabled
+  Given stdio output is captured
+  When the suite is executed
+  Then stdout contains
+  """
+  ..Hello world
+  ......Hello world
+  ..F.
+
+  Failures:
+
+  1) Scenario: error
+     ✔ Before
+     ✔ Before
+     ✔ When message Hello world is written to stdout
+     ✔ And message Bye Bye is written to stderr
+     ✖ Then error
+         Error: Error
+
+         Captured Output
+         ===============
+         Std Err
+         -------
+         Bye Bye
+
+
+         Std Out
+         -------
+         Hello world
+
+     ✔ After
+
+  2 scenarios (1 failed, 1 passed)
+  6 steps (1 failed, 5 passed)
+  """
+  And stderr contains
+  """
+  Bye Bye
+  Bye Bye
+  """
+
+Scenario: Capture enabled and suppression enabled
+  Given stdio output is captured
+  And stdio output is suppressed
+  When the suite is executed
+  Then stdout contains
+  """
+  ..........F.
+
+  Failures:
+
+  1) Scenario: error
+     ✔ Before
+     ✔ Before
+     ✔ When message Hello world is written to stdout
+     ✔ And message Bye Bye is written to stderr
+     ✖ Then error
+         Error: Error
+
+         Captured Output
+         ===============
+         Std Err
+         -------
+         Bye Bye
+
+
+         Std Out
+         -------
+         Hello world
+
+     ✔ After
+
+  2 scenarios (1 failed, 1 passed)
+  6 steps (1 failed, 5 passed)
+  """
+  And stderr contains
+  """
+  """
+
+Scenario: Capture disabled and suppression enabled
+  Given stdio output is suppressed
+  When the suite is executed
+  Then stdout contains
+  """
+  ..........F.
+
+  Failures:
+
+  1) Scenario: error
+     ✔ Before
+     ✔ Before
+     ✔ When message Hello world is written to stdout
+     ✔ And message Bye Bye is written to stderr
+     ✖ Then error
+         Error: Error
+     ✔ After
+
+  2 scenarios (1 failed, 1 passed)
+  6 steps (1 failed, 5 passed)
+  """
+  And stderr contains
+  """
+  """
+
+Scenario: Debug enabled and capture and supression enabled
+  Given feature file is
+  """
+  Feature: test with debug
+  Scenario: all ok
+    When message Hello world is written to stdout
+    And message Bye Bye is written to stderr
+    Then no error
+  """
+  Given stdio output is captured
+  And stdio output is suppressed
+  And debug module is enabled
+  When the suite is executed
+  Then stdout contains
+  """
+  .Hello world
+  ....
+
+  1 scenario (1 passed)
+  3 steps (3 passed)
+  """
+  And stderr contains
+  """
+  Bye Bye
+  """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,6 +533,17 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -638,6 +649,23 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "execa": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -682,6 +710,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -717,6 +751,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
     "indent-string": {
@@ -771,6 +811,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "js-tokens": {
@@ -836,6 +882,18 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
       "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -900,6 +958,15 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
       "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
     },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -911,6 +978,15 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
       }
     },
     "pad-right": {
@@ -925,6 +1001,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -1029,6 +1111,27 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "source-map": {
@@ -1145,6 +1248,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "supports-color": {
@@ -1403,6 +1512,15 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Cucumber test runner with several condiments",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node-fetch": "^2.1.2",
     "@types/progress": "2.0.3",
     "durations": "3.4.2",
+    "execa": "5.0.0",
     "ts-unused-exports": "^7.0.3",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.9.2",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,6 +22,7 @@ runTest() {
   MONGO_URI=$WITH_MONGODB \
   ELASTIC_URI=$WITH_ELASTIC \
   ./node_modules/.bin/cucumber-js \
+    --publish-quiet \
     --require-module ts-node/register \
     -r src/test.ts \
     $*

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import setupHttp from './http';
 import setupMisc from './misc';
 import { getOpSpec } from './operators';
 import printOperators, { printError } from './operators/printer';
+import { setupOutputCapture } from './output';
 import setupRequireMock from './require';
 import stepCtor from './steps/constructor';
 import printSteps from './steps/printer';
@@ -44,12 +45,14 @@ const setup = (
 
   const {
     aliases = {},
+    captureOutput,
     debug,
     elasticSearchIndexUri,
     entities = {},
     http,
     operators = {},
     requireMocks,
+    suppressOutput,
     timeout,
     usage,
   } = options;
@@ -109,7 +112,9 @@ const setup = (
   if (hasEntities) setupEntities(entities, args);
   if (elasticSearchIndexUri) defineElasticSteps(elasticSearchIndexUri, args);
   if (http) setupHttp(http, args);
-
+  if (!debug && (captureOutput || suppressOutput)) {
+    setupOutputCapture(captureOutput, suppressOutput);
+  }
   fn(args);
 
   if (usage) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,0 +1,76 @@
+import { AfterStep, Before, BeforeStep, Status } from '@cucumber/cucumber';
+import {
+  ITestStepHookParameter,
+} from '@cucumber/cucumber/lib/support_code_library_builder/types';
+
+const NO_OUTPUT = '<Nothing was captured>';
+
+interface Writable {
+  write: (a: string) => void;
+}
+
+interface Interceptor {
+  capturedData: string[];
+  restore: () => void;
+  intercept: () => void;
+}
+
+const intercept = (
+  target: Writable,
+  capture?: boolean,
+  suppress?: boolean,
+): Interceptor => {
+  const capturedData: string[] = [];
+  const originalWrite = target.write;
+  return {
+    capturedData,
+    intercept: () => {
+      target.write = (a: string) => {
+        if (capture) {
+          capturedData.push(a);
+        }
+        if (!suppress) {
+          originalWrite.call(target, a);
+        }
+      };
+    },
+    restore: () => {
+      target.write = originalWrite;
+    },
+  };
+};
+
+export const setupOutputCapture = (capture?: boolean, suppress?: boolean) => {
+  let stdOutInterceptor: Interceptor;
+  let stdErrInterceptor: Interceptor;
+
+  Before(() => {
+    stdOutInterceptor = intercept(process.stdout, capture, suppress);
+    stdErrInterceptor = intercept(process.stderr, capture, suppress);
+  });
+
+  BeforeStep(() => {
+    stdOutInterceptor.intercept();
+    stdErrInterceptor.intercept();
+  });
+
+  AfterStep((arg: ITestStepHookParameter) => {
+    if (capture && arg.result.status === Status.FAILED) {
+      arg.result.message += [
+        '',
+        '',
+        'Captured Output',
+        '===============',
+        'Std Err',
+        '-------',
+        stdErrInterceptor.capturedData.join('') || NO_OUTPUT,
+        '',
+        'Std Out',
+        '-------',
+        stdOutInterceptor.capturedData.join('') || NO_OUTPUT,
+      ].join('\n');
+    }
+    stdOutInterceptor.restore();
+    stdErrInterceptor.restore();
+  });
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,13 +17,15 @@ export interface RequireMockMap {
 
 export interface Options {
   aliases?: Aliases;
+  captureOutput?: boolean;
   debug?: boolean;
   elasticSearchIndexUri?: string;
   entities?: EntityMap;
-  initialContext?: () => Context;
   http?: HttpFn;
+  initialContext?: () => Context;
   operators?: OperatorMap;
   requireMocks?: RequireMockMap;
+  suppressOutput?: boolean;
   timeout?: number;
   usage?: boolean;
 }


### PR DESCRIPTION
This change introduces two new config settings:
- `captureOutput` that stores all stdio for the current scenario and is displayed when an error happens
- `suppressOutput` that prevents strings being printed on stdio (interleaving with the dots)

![image](https://user-images.githubusercontent.com/126787/118325978-a6d85e00-b4da-11eb-97f8-3f15176ab9a3.png)
