### PR TITLE
Monkeypatch the cucumber stack filters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { getOpSpec } from './operators';
 import printOperators, { printError } from './operators/printer';
 import { setupOutputCapture } from './output';
 import setupRequireMock from './require';
+import { monkeypatchStackFilters } from './stack-filters';
 import stepCtor from './steps/constructor';
 import printSteps from './steps/printer';
 import { Step, StepKind } from './steps/types';
@@ -56,12 +57,16 @@ const setup = (fn: SetupFn, options: Options = {}): Step[] => {
     elasticSearchIndexUri,
     entities = {},
     http,
+    monkeypatchCucumber,
     operators = {},
     requireMocks,
     suppressOutput,
     timeout,
     usage,
   } = options;
+  if (monkeypatchCucumber) {
+    monkeypatchStackFilters();
+  }
 
   if (!debug && (captureOutput || suppressOutput)) {
     setupOutputCapture(captureOutput, suppressOutput);

--- a/src/stack-filters.ts
+++ b/src/stack-filters.ts
@@ -1,0 +1,19 @@
+import * as filters from '@cucumber/cucumber/lib/stack_trace_filter';
+import path from 'path';
+
+export const monkeypatchStackFilters = (): void => {
+  const projectRootPath = path.join(__dirname, '..');
+  const projectChildDirs = ['src'];
+
+  const originalIsFilenameInCucumber = filters.isFileNameInCucumber;
+
+  const isFileNameInPickledCucumber = (fileName: string): boolean =>
+    originalIsFilenameInCucumber(fileName) ||
+    projectChildDirs.some((dir) =>
+      fileName.startsWith(path.join(projectRootPath, dir)),
+    );
+
+  (filters as {
+    isFileNameInCucumber: (f: string) => boolean;
+  }).isFileNameInCucumber = isFileNameInPickledCucumber;
+};

--- a/src/test.ts
+++ b/src/test.ts
@@ -84,6 +84,7 @@ const options: Options = {
     },
     initialFive: 5,
   }),
+  monkeypatchCucumber: true,
   requireMocks: {
     'totally-random-module': 42,
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface Options {
   entities?: EntityMap;
   http?: HttpFn;
   initialContext?: () => Context;
+  monkeypatchCucumber?: boolean;
   operators?: OperatorMap;
   requireMocks?: RequireMockMap;
   suppressOutput?: boolean;


### PR DESCRIPTION
This function is used to calculate failure errors paths to steps.
Without this patch, the decorators over step functions are displayed,
instead of the code implementing the step.

This change involves touching internal state of cucumber, and that is a
tradeoff with user experience.

For users of the library, should be easier to debug broken tests,
instead of purity on the codebase.