### PR TITLE
Elasticsearch: Prefer refreshing the index over flushing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Cucumber test runner with several condiments",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/entities/elasticsearch.ts
+++ b/src/entities/elasticsearch.ts
@@ -57,7 +57,6 @@ const create = <T, Tid extends keyof T>(
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   const search = async (criteria: object) => {
-    await flush();
     const docs = await request<QueryResults<T>>(
       'POST',
       `${indexUri}/_search`,

--- a/src/entities/elasticsearch.ts
+++ b/src/entities/elasticsearch.ts
@@ -53,7 +53,10 @@ const create = <T, Tid extends keyof T>(
   idProperty: Tid,
   opts: Options<T, Tid> = {},
 ): Entity<T, Tid> => {
-  const flush = () => request('POST', `${indexUri}/_flush`);
+  // Refresh the index so that all operations performed since the last refresh
+  // are available for search.
+  // See https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-refresh.html
+  const refresh = () => request('POST', `${indexUri}/_refresh`);
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   const search = async (criteria: object) => {
@@ -86,14 +89,14 @@ const create = <T, Tid extends keyof T>(
 
       const routing = opts.getRouting && opts.getRouting(record);
       await request('PUT', getRecordUri(routing, record), record);
-      await flush();
+      await refresh();
       return record;
     },
     delete: async (idOrObject) => {
       const doc = await getById(idOrObject);
       if (!doc) return;
       await request('DELETE', getRecordUri(doc._routing, doc._source));
-      await flush();
+      await refresh();
     },
     findBy: async (criteria) => getSource(await search(criteria)),
     findById: async (idOrObject) => getSource(await getById(idOrObject)),
@@ -108,7 +111,7 @@ const create = <T, Tid extends keyof T>(
         : recordWithAttrs;
 
       await entity.create(recordWithChanges);
-      await flush();
+      await refresh();
       return recordWithChanges;
     },
   };
@@ -125,7 +128,7 @@ export const defineElasticSteps = (
   When(
     'searching for',
     async (payload) => {
-      await request('POST', `${indexUri}/_flush`);
+      await request('POST', `${indexUri}/_refresh`);
       setCtx(
         '$search-results',
         await request('POST', `${indexUri}/_search`, JSON.parse(payload)),


### PR DESCRIPTION
[Flushing the index](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-flush.html) is an expensive operation that persists the index to disk. For tests it's more appropriate to [refresh the index](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-refresh.html).

Refreshing instead of flushing should speed up tests while continuing to ensure that that all indexing operations performed are immediately available for search.

Additionally, remove the index flush/refresh before searching. Assuming that the index is not modified externally, it should be sufficient to refresh the index only after the create, delete, and update operations.