### PR TITLE
Add 'does not include' assertion operator

### DIFF
--- a/features/operators/negative/does-not-include.feature
+++ b/features/operators/negative/does-not-include.feature
@@ -1,0 +1,58 @@
+Feature: compare JSON does not include X
+
+Scenario: { "a": 1 } does not include {}
+  Given A is { "a": 1 }
+  When asserting that A does not include {}
+  Then the assertion fails with {"a":1} does include {}
+
+Scenario: { "a": 1 } does not include { "a": 1 }
+  Given A is { "a": 1 }
+  When asserting that A does not include { "a": 1 }
+  Then the assertion fails with {"a":1} does include {"a":1}
+
+Scenario: { "a": 1, "b": 1 } does not include { "a": 1 }
+  Given A is { "a": 1, "b": 1 }
+  When asserting that A does not include { "a": 1 }
+  Then the assertion fails with {"a":1,"b":1} does include {"a":1}
+
+Scenario: { "a": 1 } does not include { "a": 2 }
+  Given A is { "a": 1 }
+  When asserting that A does not include { "a": 2 }
+  Then the assertion passes
+
+Scenario: [1, 2] does not include 1
+  Given A is [1, 2]
+  When asserting that A does not include 1
+  Then the assertion fails with [1,2] does include 1
+  And the error path is "0"
+
+Scenario: [{ "a": 1 }] does not include { "a": 2 }
+  Given A is [{ "a": 1 }]
+  When asserting that A does not include { "a": 2 }
+  Then the assertion passes
+
+Scenario: [{ "a": 1 }, { "a": 2 }] includes { "a": 2 }
+  Given A is [{ "a": 1 }, { "a": 2 }]
+  When asserting that A does not include { "a": 2 }
+  Then the assertion fails with [{"a":1},{"a":2}] does include {"a":2}
+  And the error path is "1"
+
+Scenario: { "members": [] } does not include { "members": ["a"] }
+  Given A is { "members": [] }
+  When asserting that A does not include { "members": ["a"] }
+  Then the assertion passes
+
+Scenario: { "a": { "b": 1, "c": 1 } } does not include { "a": { "b": 1 } }
+  Given A is { "a": { "b": 1, "c": 1 } }
+  When asserting that A does not include { "a": { "b": 1 } }
+  Then the assertion fails with {"a":{"b":1,"c":1}} does include {"a":{"b":1}}
+
+Scenario: {} does not include { "a": null }
+  Given A is {}
+  When asserting that A does not include { "a": null}
+  Then the assertion fails with {} does include {"a":null}
+
+Scenario: [] does not include { "a": 1 }
+  Given A is []
+  When asserting that A does not include { "a": 1 }
+  Then the assertion passes

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,6 +1,7 @@
 import opDoesNotContain from './negative/does-not-contain';
 import opDoesNotExist from './negative/does-not-exist';
 import opDoesNotHaveKeys from './negative/does-not-have-keys';
+import opDoesNotInclude from './negative/does-not-include';
 import opDoesNotMatch from './negative/does-not-match';
 import opIsNot from './negative/is-not';
 import opContains from './positive/contains';
@@ -17,6 +18,7 @@ const OPERATORS = [
   opDoesNotContain,
   opDoesNotExist,
   opDoesNotHaveKeys,
+  opDoesNotInclude,
   opDoesNotMatch,
   opExists,
   opHasKeys,

--- a/src/operators/negative/does-not-include.ts
+++ b/src/operators/negative/does-not-include.ts
@@ -1,4 +1,4 @@
-import { findOffendingItem } from '../../util';
+import { findPartialInCollection } from '../../util';
 import { Operator } from '../types';
 
 const op: Operator = {
@@ -6,7 +6,7 @@ const op: Operator = {
   description: `checks that the array or object 'a' does not include the partial 'b'`,
   exec: (actual, expected) => {
     const expectedJson = JSON.parse(expected);
-    const offending = findOffendingItem(actual, expectedJson);
+    const offending = findPartialInCollection(actual, expectedJson);
 
     if (!offending.matched) return undefined;
 

--- a/src/operators/negative/does-not-include.ts
+++ b/src/operators/negative/does-not-include.ts
@@ -8,12 +8,13 @@ const op: Operator = {
     const expectedJson = JSON.parse(expected);
     const offending = findOffendingItem(actual, expectedJson);
 
-    if (offending.path !== undefined) return undefined;
+    if (!offending.matched) return undefined;
 
     return {
       assertEquals: true,
       error: 'does include',
       expected: expectedJson,
+      path: offending.path,
     };
   },
   name: ['do not include', 'does not include'],

--- a/src/operators/negative/does-not-include.ts
+++ b/src/operators/negative/does-not-include.ts
@@ -1,0 +1,22 @@
+import { findOffendingItem } from '../../util';
+import { Operator } from '../types';
+
+const op: Operator = {
+  arity: 'binary',
+  description: `checks that the array or object 'a' does not include the partial 'b'`,
+  exec: (actual, expected) => {
+    const expectedJson = JSON.parse(expected);
+    const offending = findOffendingItem(actual, expectedJson);
+
+    if (offending.path !== undefined) return undefined;
+
+    return {
+      assertEquals: true,
+      error: 'does include',
+      expected: expectedJson,
+    };
+  },
+  name: ['do not include', 'does not include'],
+};
+
+export default op;

--- a/src/operators/positive/includes.ts
+++ b/src/operators/positive/includes.ts
@@ -8,7 +8,7 @@ const op: Operator = {
     const expectedJson = JSON.parse(expected);
     const offending = findOffendingItem(actual, expectedJson);
 
-    if (offending.path === undefined) return undefined;
+    if (offending.matched) return undefined;
 
     return {
       assertEquals: true,

--- a/src/operators/positive/includes.ts
+++ b/src/operators/positive/includes.ts
@@ -1,4 +1,4 @@
-import { findOffendingItem, getDeep, NOT_IN_ARRAY } from '../../util';
+import { findPartialInCollection, getDeep, NOT_IN_ARRAY } from '../../util';
 import { Operator } from '../types';
 
 const op: Operator = {
@@ -6,7 +6,7 @@ const op: Operator = {
   description: `checks that the array or object 'a' includes the partial 'b'`,
   exec: (actual, expected) => {
     const expectedJson = JSON.parse(expected);
-    const offending = findOffendingItem(actual, expectedJson);
+    const offending = findPartialInCollection(actual, expectedJson);
 
     if (offending.matched) return undefined;
 

--- a/src/operators/positive/includes.ts
+++ b/src/operators/positive/includes.ts
@@ -1,53 +1,9 @@
-import { getDeep, recursiveMatch } from '../../util';
+import { findOffendingItem, getDeep, NOT_IN_ARRAY } from '../../util';
 import { Operator } from '../types';
-
-interface Offending {
-  actual: unknown;
-  path: string | undefined;
-}
-
-const isObject = (item: unknown): item is Record<string, unknown> =>
-  typeof item === 'object' && !Array.isArray(item) && item !== null;
-
-const recursiveIncludes = (
-  actual: unknown,
-  expectedPartial: unknown,
-  path?: string,
-) => {
-  const expected =
-    isObject(actual) && isObject(expectedPartial)
-      ? { ...actual, ...expectedPartial } // make a whole object from a partial
-      : expectedPartial; // is a primitive or array
-
-  return recursiveMatch(actual, expected, path, true);
-};
-
-const NOT_IN_ARRAY = {};
-
-const findOffendingItem = (actual: unknown, expected: string): Offending => {
-  if (!Array.isArray(actual)) {
-    return { actual, path: recursiveIncludes(actual, expected) };
-  }
-
-  const items = actual.map((a, i) => ({
-    actual: a,
-    path: recursiveIncludes(a, expected, `${i}`),
-  }));
-
-  if (items.some((i) => !i.path)) {
-    return { actual, path: undefined };
-  }
-
-  if (!items.length) {
-    return { actual: NOT_IN_ARRAY, path: '0' };
-  }
-
-  return { actual: NOT_IN_ARRAY, path: items[0].path };
-};
 
 const op: Operator = {
   arity: 'binary',
-  description: `checks that the array or object 'a' contains the partial 'b'`,
+  description: `checks that the array or object 'a' includes the partial 'b'`,
   exec: (actual, expected) => {
     const expectedJson = JSON.parse(expected);
     const offending = findOffendingItem(actual, expectedJson);

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,8 @@ export type SetupFnArgs = Pick<
   Then: StepDefinitionFn;
   When: StepDefinitionFn;
 };
+
+export interface OffendingItemResult {
+  actual: unknown;
+  path: string | undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type SetupFnArgs = Pick<
   When: StepDefinitionFn;
 };
 
-export interface RecursivePartialMatchResult {
+export interface PartialFindResult {
   actual?: unknown;
   matched: boolean;
   path: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,8 @@ export type SetupFnArgs = Pick<
   When: StepDefinitionFn;
 };
 
-export interface OffendingItemResult {
-  actual: unknown;
-  path: string | undefined;
+export interface RecursivePartialMatchResult {
+  actual?: unknown;
+  matched: boolean;
+  path: string;
 }


### PR DESCRIPTION
The negative version of `include` operator seems to be missing, this PR tries to add it

- Moved the `findOffendingItem` fn to utils so it can be reused in both Operations.
- `subError` describes at which property the `recursiveMatch` failed. But for `does not include` failures, I just used `errorPath`.
When `does not include` fails, `errorPath` indicates at which index the occurrence was indeed found (took the same approach as `is not` operator)