### PR TITLE
Add rule name to test output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Cucumber test runner with several condiments",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/formatter/progress-and-profile.ts
+++ b/src/formatter/progress-and-profile.ts
@@ -42,17 +42,34 @@ export default class ProgressAndProfileFormatter extends SummaryFormatter {
     );
     const coloredStatus = this.formatStatus(status);
 
-    const coloredFeature = this.colorFns.tag(
-      gherkinDocument.feature?.name ?? '<Empty>',
-    );
+    const ruleId = pickle.astNodeIds[0];
+    let ruleName = '';
+    gherkinDocument.feature?.children.forEach(({ rule }) => {
+      if (rule?.children?.some(({ scenario }) => scenario?.id === ruleId))
+        ruleName = rule?.name;
+    });
+    const coloredFeature =
+      gherkinDocument.feature &&
+      this.formatFeature(gherkinDocument.feature, ruleName);
 
     const humaneDuration = humanizeDuration(scenarioDuration(parsed));
 
     this.log(
-      `[${coloredStatus}] (${humaneDuration}) ${coloredFeature} ${this.colorFns.location(
-        '>',
-      )} ${pickle.name} # ${formattedLocation}\n`,
+      `[${coloredStatus}] (${humaneDuration}) ${coloredFeature} ${pickle.name} # ${formattedLocation}\n`,
     );
+  }
+
+  private formatFeature(feature: messages.Feature, rule?: string) {
+    if (rule) {
+      return `${this.colorFns.tag(feature.name)} ${this.colorFns.location(
+        '>',
+      )} ${this.colorFns.tag(rule)} ${this.colorFns.location('>')}`;
+    } else if (feature.name) {
+      return `${this.colorFns.tag(feature.name)} ${this.colorFns.location(
+        '>',
+      )}`;
+    }
+    return '<Empty>';
   }
 
   private formatStatus(status: messages.TestStepResultStatus): string {


### PR DESCRIPTION
In the interest of being able to test multiple scenarios that may share the same name under different Rules, this should output the Rule name.

Example:
```
Feature: variable assertion

Rule: Positive
  Scenario: is
    Given variable P is a
    Then the variable P is "a"

  Scenario: contains
    Given variable P is abc
    Then the variable P contains "b"

  Scenario: matches
    Given variable P is abc
    Then the variable P matches [a-c]

  Scenario: starts with
    Given variable P is abc
    Then the variable P starts with "ab"

Rule: Negative
  Scenario: is
    Given variable P is a
    Then the variable P isn't "b"

  Scenario: contains
    Given variable P is abc
    Then the variable P does not contain "d"

  Scenario: matches
    Given variable P is abc
    Then the variable P does not match [d-z]
```

Test summary:
```
[PASSED] (2.00 ms) variable assertion > Positive > is # features/misc/variables.feature:4
[PASSED] (1.00 ms) variable assertion > Positive > contains # features/misc/variables.feature:8
[PASSED] (1.00 ms) variable assertion > Positive > matches # features/misc/variables.feature:12
[PASSED] (1.00 ms) variable assertion > Positive > starts with # features/misc/variables.feature:16
[PASSED] (1.00 ms) variable assertion > Negative > is # features/misc/variables.feature:21
[PASSED] (1.00 ms) variable assertion > Negative > contains # features/misc/variables.feature:25
[PASSED] (1.00 ms) variable assertion > Negative > matches # features/misc/variables.feature:29
7 scenarios (7 passed)
14 steps (14 passed)
```