### PR TITLE
Fix ES search not refreshing the index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Cucumber test runner with several condiments",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/entities/elasticsearch.ts
+++ b/src/entities/elasticsearch.ts
@@ -60,6 +60,12 @@ const create = <T, Tid extends keyof T>(
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   const search = async (criteria: object) => {
+    // We need to call refresh here to account for the "subject under test" code
+    // updating the index. When running our test-side queries we want to make
+    // sure we are seeing the latest index to prevent race conditions. This can
+    // be improved further if we detect that we just refreshed in the previous
+    // step but that detection is proving difficult to implement consistently.
+    await refresh();
     const docs = await request<QueryResults<T>>(
       'POST',
       `${indexUri}/_search`,


### PR DESCRIPTION
Bring back index refreshes before searches to prevent ES index caching race conditions such as:
1) Prod code updates index (e.g. create document)
2) ES queues changes but does not apply them
3) Test code asserts changes and fails (e.g. document not found, yet)