### PR TITLE
RN-567 Add 'approximates' operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-## [2.1.1] - YYYY-MM-DD
+## [6.1.1] - YYYY-MM-DD
 
+## [6.1.0] - 2022-12-01
+### Added
+  - Add new `approximates` operator for better floating point comparisons which allows to specify error margin. e.g. `N approximates 7.5 +- 0.1`
+
+## [6.0.0] - ????-??-??
+  - ???
+  
+## [2.1.1] - YYYY-MM-DD
 ### Added
   - redis entities adapter
   - documentation on how to extend operators

--- a/features/operators/positive/approximates.feature
+++ b/features/operators/positive/approximates.feature
@@ -1,0 +1,51 @@
+Feature: Compare approximates
+
+Scenario: Default approximation passes
+  Given N is 11.999
+  When asserting that N approximates 12
+  Then the assertion passes
+
+Scenario: Custom error margin doesn't pass
+  Given N is 11.999
+  When asserting that N approximates 12 +- 0.0001
+  Then the assertion fails with 11.999 is not approximately "12 +- 0.0001"
+
+Scenario: Custom error margin doesn't pass (different writing)
+  Given N is 11.999
+  When asserting that N approximates 12-+0.0001
+  Then the assertion fails with 11.999 is not approximately "12 +- 0.0001"
+
+Scenario: Actual is not a number
+  Given N is "hola maquinola"
+  When asserting that N approximates 12-+0.001
+  Then the assertion fails with "hola maquinola" is not a number and can't approximate "12-+0.001"
+
+Scenario: Expected is not a number with or without error margin
+  Given N is 11.99
+  When asserting that N approximates pistola
+  Then the assertion fails with 11.99 'expected' in incorrect approximate format "pistola"
+
+Scenario: Negative vs negative number
+  Given N is -5.001
+  When asserting that N approximates -5
+  Then the assertion passes
+
+Scenario: Negative vs positive number
+  Given N is -5.001
+  When asserting that N approximates 5
+  Then the assertion fails with -5.001 is not approximately "5 +- 0.001"
+
+Scenario: Positive vs negative number
+  Given N is 5.001
+  When asserting that N approximates -5
+  Then the assertion fails with 5.001 is not approximately "-5 +- 0.001"
+
+Scenario: Big number
+  Given N is 1234567.9999
+  When asserting that N approximates 1234568 +- 0.0001
+  Then the assertion passes
+
+Scenario: Small number
+  Given N is 0.12345679999
+  When asserting that N approximates 0.1234568 +- 0.00000000001
+  Then the assertion passes  

--- a/features/operators/positive/approximates.feature
+++ b/features/operators/positive/approximates.feature
@@ -15,6 +15,11 @@ Scenario: Custom error margin doesn't pass (different writing)
   When asserting that N approximates 12-+0.0001
   Then the assertion fails with 11.999 is not approximately "12 +- 0.0001"
 
+Scenario: Custom error margin doesn't pass (cute writing)
+  Given N is 11.999
+  When asserting that N approximates 12±0.0001
+  Then the assertion fails with 11.999 is not approximately "12 +- 0.0001"
+
 Scenario: Actual is not a number
   Given N is "hola maquinola"
   When asserting that N approximates 12-+0.001
@@ -23,7 +28,7 @@ Scenario: Actual is not a number
 Scenario: Expected is not a number with or without error margin
   Given N is 11.99
   When asserting that N approximates pistola
-  Then the assertion fails with 11.99 'expected' in incorrect approximate format "pistola"
+  Then the assertion fails with 11.99 . 'pistola' is not a valid approximation specification. Please use any of the following: <number> or <number> +- <positive-number> "pistola"
 
 Scenario: Negative vs negative number
   Given N is -5.001
@@ -49,3 +54,33 @@ Scenario: Small number
   Given N is 0.12345679999
   When asserting that N approximates 0.1234568 +- 0.00000000001
   Then the assertion passes  
+
+Scenario: Integer pass
+  Given N is 15
+  When asserting that N approximates 20 +- 5
+  Then the assertion passes  
+
+Scenario: Integer pass bis
+  Given N is 25
+  When asserting that N approximates 20 +- 5
+  Then the assertion passes  
+
+Scenario: Integer fail
+  Given N is 27
+  When asserting that N approximates 20 +- 5
+  Then the assertion fails with 27 is not approximately "20 +- 5"
+
+Scenario: Right in the "middle"
+  Given N is 20
+  When asserting that N approximates 20 +- 5
+  Then the assertion passes
+
+Scenario: Explanation epsilon example
+  Given N is 1234567.9999
+  When asserting that N approximates 1234568 +- 0.0001
+  Then the assertion passes
+
+Scenario: Lot's of digits highest precision
+  Given N is 3.141592653589793115997963468544185161590576171875
+  When asserting that N approximates 3.141592653589793115997963468544185161590576171875 +- 0.0000000004
+  Then the assertion passes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pickled-cucumber",
-  "version": "4.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pickled-cucumber",
-      "version": "4.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Cucumber test runner with several condiments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -3,6 +3,7 @@ import opDoesNotExist from './negative/does-not-exist';
 import opDoesNotHaveKeys from './negative/does-not-have-keys';
 import opDoesNotMatch from './negative/does-not-match';
 import opIsNot from './negative/is-not';
+import opApproximates from './positive/approximates';
 import opContains from './positive/contains';
 import opExists from './positive/exists';
 import opHasKeys from './positive/has-keys';
@@ -25,6 +26,7 @@ const OPERATORS = [
   opIsNot,
   opMatches,
   opStartsWith,
+  opApproximates,
 ].reduce<OperatorMap>((acc, op) => {
   if (typeof op.name === 'string') acc[op.name] = op;
   else op.name.forEach((name) => (acc[name] = op));

--- a/src/operators/positive/approximates.ts
+++ b/src/operators/positive/approximates.ts
@@ -4,15 +4,23 @@ import { Operator } from '../types';
 // Operator to check approximate numbers
 // By default the approximation uses +- 0.001 (DEFAULT_ERROR_MARGIN)
 
-// We use ERROR_EPSILON to give an extra tiny rounding leeway to fix
-// floating-point errors for big numbers "on the fence", up to 8 significant
-// digits. For example:
-//                                               v--- uh-oh
-// (12345679 - 12345678.9999).toFixed(60) = 0.000099999830126762390136718...
-//                        + ERROR_EPSILON = 0.0000000002
-//                                        = 0.000100000030126762390575261...
-//                                               ^--- ok!
-// This avoids triggering a false failure on edge cases.
+// We use ERROR_EPSILON to give an extra tiny rounding leeway to fix floating
+// point errors for big numbers "on the fence", up to 8 significant digits.
+// For example:
+//
+// Checking 1234567.9999 vs (1234568 +- 0.0001) should match, but in reality...
+//
+//                 uh-oh, it's a tiny bit over 0.0001 due
+//                    to floating point precision errors!
+//                                                       \
+//                 (1234568 - 1234567.9999) = 0.000100000062957406044006347656
+//                            ERROR_EPSILON = 0.0000000002
+// (1234568 - 1234567.9999) - ERROR_EPSILON = 0.000099999862957406043567805398
+//                                                  \
+//                                                   OK! still under the margin
+//
+// By slightly *contracting the difference* to account for added precision
+// error, comparison against the exact error margin won't trigger a false fail.
 const ERROR_EPSILON = 0.0000000002;
 
 const DEFAULT_ERROR_MARGIN = '0.001';
@@ -29,25 +37,31 @@ const op: Operator = {
     //  | number
     //  | number "+-" positive-number
     //  | number "-+" positive-number
+    //  | number "±" positive-number
     const match = expected
       .trim()
       .match(
-        /^(-?[0-9^.]+|-?[0-9]*\.[0-9]+) *(?:(?:-\+|\+-) *([0-9^.]+|[0-9]*\.[0-9]+))?$/,
+        /^(-?[0-9^.]+|-?[0-9]*\.[0-9]+) *(?:(?:-\+|\+-|±) *([0-9^.]+|[0-9]*\.[0-9]+))?$/,
       );
 
-    if (!match)
-      return { error: "'expected' in incorrect approximate format", expected };
+    if (!match) {
+      return {
+        error: `. '${expected}' is not a valid approximation specification. Please use any of the following: <number> or <number> +- <positive-number>`,
+        expected,
+      };
+    }
 
     const expectedNumber = parseFloat(match[1]);
     const expectedErrorMargin = parseFloat(match[2] ?? DEFAULT_ERROR_MARGIN);
 
     if (
-      Math.abs(expectedNumber - actualNumber) >
-      expectedErrorMargin + ERROR_EPSILON
+      Math.abs(expectedNumber - actualNumber) - ERROR_EPSILON >
+      expectedErrorMargin
     ) {
       return {
         error: 'is not approximately',
         expected: `${expectedNumber} +- ${expectedErrorMargin}`,
+        actual: actualNumber,
       };
     }
 

--- a/src/operators/positive/approximates.ts
+++ b/src/operators/positive/approximates.ts
@@ -1,0 +1,59 @@
+import { getString } from '../../util';
+import { Operator } from '../types';
+
+// Operator to check approximate numbers
+// By default the approximation uses +- 0.001 (DEFAULT_ERROR_MARGIN)
+
+// We use ERROR_EPSILON to give an extra tiny rounding leeway to fix
+// floating-point errors for big numbers "on the fence", up to 8 significant
+// digits. For example:
+//                                               v--- uh-oh
+// (12345679 - 12345678.9999).toFixed(60) = 0.000099999830126762390136718...
+//                        + ERROR_EPSILON = 0.0000000002
+//                                        = 0.000100000030126762390575261...
+//                                               ^--- ok!
+// This avoids triggering a false failure on edge cases.
+const ERROR_EPSILON = 0.0000000002;
+
+const DEFAULT_ERROR_MARGIN = '0.001';
+
+const op: Operator = {
+  arity: 'binary',
+  description: `checks that the number 'a' approximates number 'b'`,
+  exec: (actual, expected) => {
+    const actualNumber = parseFloat(getString(actual));
+    if (Number.isNaN(actualNumber))
+      return { error: "is not a number and can't approximate", expected };
+
+    // expected :=
+    //  | number
+    //  | number "+-" positive-number
+    //  | number "-+" positive-number
+    const match = expected
+      .trim()
+      .match(
+        /^(-?[0-9^.]+|-?[0-9]*\.[0-9]+) *(?:(?:-\+|\+-) *([0-9^.]+|[0-9]*\.[0-9]+))?$/,
+      );
+
+    if (!match)
+      return { error: "'expected' in incorrect approximate format", expected };
+
+    const expectedNumber = parseFloat(match[1]);
+    const expectedErrorMargin = parseFloat(match[2] ?? DEFAULT_ERROR_MARGIN);
+
+    if (
+      Math.abs(expectedNumber - actualNumber) >
+      expectedErrorMargin + ERROR_EPSILON
+    ) {
+      return {
+        error: 'is not approximately',
+        expected: `${expectedNumber} +- ${expectedErrorMargin}`,
+      };
+    }
+
+    return undefined;
+  },
+  name: 'approximates',
+};
+
+export default op;


### PR DESCRIPTION
Add new `approximates` operator for better floating point comparisons which allows to specify error margin.
e.g. `N approximates 7.5 +- 0.1` or just `N approximates 7.5` for a default 0.001 margin.