### PR TITLE
Add a payload parser to support JSON payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Build
 on:
-  push:
+  push: {}
+  pull_request:
+    types: [opened, reopened]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/features/misc/parser.feature
+++ b/features/misc/parser.feature
@@ -1,0 +1,27 @@
+Feature: payload parser 
+
+Scenario: happy path
+  Then JSON representation of the payload is {"a":1,"b":2}
+  """
+  { 
+    "a": 1, 
+    "b": 2 
+  }
+  """
+
+Scenario: JSON5 support
+  Given variable A is 123
+  Then JSON representation of the payload is {"a":1,"b":2,"arrays":[123,"123"],"nested":{"a":1}}
+  """
+  { 
+    a: 1, 
+    b: 2,
+    arrays: [
+      ${A},
+      "${A}",
+    ],
+    nested: {
+      "a": 1,
+    },
+  }
+  """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "pickled-cucumber",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pickled-cucumber",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber": "8.5.1",
+        "json5": "^2.2.3",
         "node-fetch": "^2.2.0",
         "ts-node": "^7.0.0"
       },
@@ -1818,15 +1819,14 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/knuth-shuffle-seeded": {
@@ -2747,6 +2747,18 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/tslib": {
@@ -4274,13 +4286,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "knuth-shuffle-seeded": {
       "version": "1.0.6",
@@ -4969,6 +4977,17 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "description": "Cucumber test runner with several condiments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@cucumber/cucumber": "8.5.1",
+    "json5": "^2.2.3",
     "node-fetch": "^2.2.0",
     "ts-node": "^7.0.0"
   },

--- a/src/steps/constructor.ts
+++ b/src/steps/constructor.ts
@@ -1,7 +1,19 @@
 import BUILT_IN_ALIASES from '../aliases';
 import { Aliases, Context } from '../types';
 import { getDeep } from '../util';
-import { Step, StepFn, StepKind, StepOptions } from './types';
+import {
+  ParserFn,
+  ParserKind,
+  Step,
+  StepFn,
+  StepKind,
+  StepOptions,
+} from './types';
+import JSON5 from 'json5';
+
+const PARSER_MAP: Record<ParserKind, ParserFn> = {
+  json: JSON5.parse,
+} as const;
 
 const getDeepString = (ctx: Context, path: string): string => {
   const v = getDeep(ctx, path);
@@ -27,16 +39,30 @@ const resolveRegExp = (aliases: Aliases, regexpString: string) =>
   );
 
 // Creates a proxy of fn that calls `expand` on every argument
-const proxyFnFor = (getCtx: () => Context, fn: StepFn, argCount: number) => {
-  // tslint:disable-next-line prefer-array-literal
-  const args = new Array(argCount).fill(undefined).map((_, i) => `a${i}`);
-  const body = `{
-    const { fn, expand } = this;
-    const ex = expand(this.getCtx());
-    return fn(${args.map((a) => `ex(${a})`).join(',')});
-  }`;
-  // tslint:disable-next-line no-function-constructor-with-string-args
-  return new Function(...args, body).bind({ getCtx, expand, fn });
+const proxyFnFor = (
+  getCtx: () => Context,
+  fn: StepFn,
+  argCount: number,
+  parserFn?: ParserFn,
+) => {
+  // this will convert the variadic args to a fixed-length function
+  // which is used internally to run the actual step definition
+  const proxyFn = (...args: string[]) => {
+    // reverse the args list handle the `payload` arg
+    const ex = expand(getCtx());
+    const [errorFn, ...fnArgs] = args.reverse();
+    const [tail, ...head] = fnArgs.map(ex);
+    const parse = parserFn ? parserFn : (x: string) => x;
+
+    const proxyArgs = [...head.reverse(), parse(tail) as any, errorFn];
+    return fn.apply(null, proxyArgs.slice(0, argCount));
+  };
+
+  // we are using this internally to differenciate the function kind
+  // this makes the 'proxyFn' mimic a N-args function just fine
+  Object.defineProperty(proxyFn, 'length', { get: () => argCount });
+
+  return proxyFn;
 };
 
 // Generates a cucumber step, with some additional features:
@@ -56,6 +82,10 @@ const proxyFnFor = (getCtx: () => Context, fn: StepFn, argCount: number) => {
 //   version of the step that does not include the last argument. Also, when
 //   `optional` is a string, that string is appended to all other version of
 //    this step. Note that setting `optional` implies `inline`
+//
+// - setting `opt.parser` will automatically add a payload parser before sending
+//   the payload to your step definition handler; currently 'json' is available
+//   available
 export default (aliases: Aliases, getCtx: () => Context) => (
   kind: StepKind,
   regexpString: string,
@@ -63,8 +93,12 @@ export default (aliases: Aliases, getCtx: () => Context) => (
   opt: StepOptions = {},
 ): Step[] => {
   // Generate a proxy of fn that calls `expand` on every argument
-  const proxyFn = proxyFnFor(getCtx, fn, fn.length);
-
+  const proxyFn = proxyFnFor(
+    getCtx,
+    fn,
+    fn.length,
+    opt.parser ? PARSER_MAP[opt.parser] : undefined,
+  );
   const allAliases = { ...BUILT_IN_ALIASES, ...aliases };
 
   const rawRegExp = resolveRegExp(allAliases, regexpString);
@@ -80,6 +114,7 @@ export default (aliases: Aliases, getCtx: () => Context) => (
       fn,
       fn.length - 1 - (suffix.match(/(\([^)]*\))/g) || []).length,
     );
+
     steps.push({
       fn: proxyFnWithoutLastArg,
       kind,

--- a/src/steps/types.ts
+++ b/src/steps/types.ts
@@ -1,8 +1,11 @@
 export type StepFn = (...args: string[]) => void;
+export type ParserFn = (raw: string) => unknown;
+export type ParserKind = 'json';
 
 export interface StepOptions {
   inline?: boolean;
   optional?: string | boolean;
+  parser?: ParserKind;
 }
 
 export type StepKind = 'Given' | 'Then' | 'When';

--- a/src/test.ts
+++ b/src/test.ts
@@ -185,6 +185,13 @@ const fn: SetupFn = ({ getCtx, Given, onTearDown, setCtx, Then, When }) => {
     assert.equal(getCtx(name), val),
   );
 
+  // === Test parser ===================================================== //
+  Then(
+    'JSON representation of the payload is (.*)',
+    (repr, payload) => assert.equal(repr, JSON.stringify(payload)),
+    { parser: 'json5' },
+  );
+
   // === Test output ======================================================== //
   Given('step definition', (payload) => setCtx('steps-definition', payload));
   Given('feature file is', (payload) =>


### PR DESCRIPTION
This change enabled step definitions to declare a parsed payload 

```
Given('…', (...args) => { … }, { parser: 'json' })
```

This will remove the need to JSON.parse in every stepdef and comes with a JSON5 parser for our human fingers.