### PR TITLE
Add support to get many documents

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0
+FROM node:18.19.1
 
 WORKDIR /usr/src
 
@@ -6,7 +6,7 @@ COPY ["package.json", "package-lock.json", "/usr/src/"]
 
 RUN npm i --loglevel=warn --porcelain --progress=false
 
-RUN npm i --no-save --loglevel=warn --porcelain --progress=false mongodb@2.2.27
+RUN npm i --no-save --loglevel=warn --porcelain --progress=false mongodb@5.8.1
 
 COPY ["tsconfig.json", "docker/wait.sh", "/usr/src/"]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,10 @@ services:
       - ../src:/usr/src/src
 
   elasticsearch:
-    image: elasticsearch:2.2.0
+    image: elasticsearch:7.16.3
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   mongodb:
     image: mongo:latest

--- a/docker/wait.sh
+++ b/docker/wait.sh
@@ -8,7 +8,7 @@ waitFor() {
     if [ $? -eq 0 ]; then echo "OK"; exit 0; fi
     I=$((I-1))
     if [ $I -eq 0 ]; then echo "Gave up"; exit 1; fi
-    sleep 1
+    sleep 5
     echo -n .
   done
 }

--- a/features/entities/elasticsearch.feature
+++ b/features/entities/elasticsearch.feature
@@ -17,6 +17,12 @@ Scenario: assert by property
   Given a search S with { "color": "red", "action": "${random}" }
   Then the document for the search with { "query": { "term": { "action": "${random}" } } } at color is "red"
 
+Scenario: assert many by property
+  Given a search S with { "color": "red", "action": "${random}" }
+  And a search S2 with { "color": "orange", "action": "${random}" }
+  Then the documents for the search with { "query": { "term": { "action": "${random}" } } } includes { "color": "red" }
+  And the documents for the search with { "query": { "term": { "action": "${random}" } } } includes { "color": "orange" }
+
 Scenario: store document variable
   Given a search S with { "color": "red", "action": "${random}" }
   And store the document for search S in U2

--- a/features/entities/memory.feature
+++ b/features/entities/memory.feature
@@ -9,6 +9,12 @@ Scenario: boxes
   And the document for the box with { "color": "blue" } at size is "big"
   And the box B3 was deleted
 
+Scenario: assert many
+  Given a box B1 with { "color": "red", "action": "${random}" }
+  And a box B2 with { "color": "green", "action": "${random}" }
+  Then the documents for the box with { "action": "${random}" } includes { "color": "red" }
+  And the documents for the box with { "action": "${random}" } includes { "color": "green" }
+
 Scenario: previous boxes should not exist
   Then the document for the box with { "color": "red" } does not exist in context
   And the document for the box with { "color": "green" } does not exist in context

--- a/features/entities/mongo.feature
+++ b/features/entities/mongo.feature
@@ -17,6 +17,12 @@ Scenario: assert by property
   Given a user U with { "color": "red", "action": "${random}" }
   Then the document for the user with { "action": "${random}" } at color is "red"
 
+Scenario: assert many by property
+  Given a user U with { "color": "red", "action": "${random}" }
+  And a user U2 with { "color": "blue", "action": "${random}" }
+  Then the documents for the user with { "action": "${random}" } includes { "color": "red" }
+  And the documents for the user with { "action": "${random}" } includes { "color": "blue" }
+
 Scenario: store document variable
   Given a user U with { "color": "red", "action": "${random}" }
   And store the document for user U in U2

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "execa": "5.0.0",
         "prettier": "2.0.5",
         "ts-unused-exports": "^7.0.3",
-        "typescript": "^3.8.3"
+        "typescript": "4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2794,9 +2794,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5017,9 +5017,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "upper-case-first": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "execa": "5.0.0",
     "prettier": "2.0.5",
     "ts-unused-exports": "^7.0.3",
-    "typescript": "^3.8.3"
+    "typescript": "4.3"
   },
   "dependencies": {
     "@cucumber/cucumber": "8.5.1",
@@ -53,7 +53,7 @@
     "lint": "eslint . && ts-unused-exports tsconfig.json",
     "lint:fix": "eslint --fix .",
     "pack": "npm run dist && npm pack",
-    "setup": "npm i  && npm i --no-save mongodb@2.2.27",
+    "setup": "npm i  && npm i --no-save mongodb@5.8.1",
     "test": "./scripts/test.sh",
     "test:docker:keep": "cd docker && docker-compose run test",
     "test:docker": "npm run test:docker:keep; cd docker && docker-compose down",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickled-cucumber",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Cucumber test runner with several condiments",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -51,6 +51,14 @@ const setup = (
     { inline: true },
   );
   Then(
+    'the documents for the {entity} with (\\{.*\\}) {op}',
+    async (entity, query, op, payload) => {
+      const docs = await entities[entity].find(JSON.parse(query));
+      compare(op, docs, payload);
+    },
+    { inline: true },
+  );
+  Then(
     'that document {op}',
     (op, payload) => compare(op, getCtx('$last-doc'), payload),
     { inline: true },

--- a/src/entities/memory.ts
+++ b/src/entities/memory.ts
@@ -21,6 +21,16 @@ const generate = <T, Tid extends keyof T>(
       entities.splice(entities.findIndex((e) => e === entity, 1));
     },
     // eslint-disable-next-line @typescript-eslint/ban-types
+    find: async (record: object) => {
+      const entries = Object.entries(record) as Entries;
+      return entities.filter(
+        (e) =>
+          entries.every((pair) => e[pair[0]] === pair[1]) ||
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (idField in record && e[idField] === (record as any)[idField]),
+      );
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-types
     findBy: async (record: object) => {
       const entries = Object.entries(record) as Entries;
       return entities.find(

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -4,6 +4,8 @@ export interface Entity<T, Tid extends keyof T> {
   create: (attrs?: T) => Promise<T>;
   delete: (idOrObject: IdOrObject<T, Tid>) => Promise<void>;
   // eslint-disable-next-line
+  find: (criteria: object) => Promise<T[]>;
+  // eslint-disable-next-line
   findBy: (criteria: object) => Promise<T | undefined | null>;
   findById: (idOrObject: IdOrObject<T, Tid>) => Promise<T | undefined | null>;
   update: (idOrObject: IdOrObject<T, Tid>, attrs: Partial<T>) => Promise<T>;

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,7 +4,6 @@ import execa from 'execa';
 import fs from 'fs';
 import nodeFetch from 'node-fetch';
 import path from 'path';
-import { promisify } from 'util';
 import compareJson from './compare-json';
 import createElasticEntity from './entities/elasticsearch';
 import createMemoryEntity from './entities/memory';
@@ -40,13 +39,13 @@ if (process.env.MONGO_URI) {
   let connected = false;
 
   const getDb = async () => {
-    if (client) return client;
+    if (client) return client.db();
 
-    client = promisify(mongo.MongoClient.connect)(process.env.MONGO_URI);
+    const conn = new mongo.MongoClient(process.env.MONGO_URI);
+    client = await conn.connect();
 
-    await client;
     connected = true;
-    return client;
+    return client.db();
   };
   AfterAll(async () => {
     if (connected) (await client).close();


### PR DESCRIPTION
This change allow support to the sentence:
```
Then the documents for the Entity with {...} includes {...}
```
That way you can make assertions on queries that return many documents instead of just one.
Adding tests for mongodb, elasticsearch and memory providers.